### PR TITLE
Translate CSRF token mismatch exception

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -82,7 +82,7 @@ class VerifyCsrfToken
             });
         }
 
-        throw new TokenMismatchException('CSRF token mismatch.');
+        throw new TokenMismatchException(__('CSRF token mismatch.'));
     }
 
     /**


### PR DESCRIPTION
Developing an entire error handler just to translate the error message is too complicated and not very logical. I suggest adding a direct translation which will make working with errors much easier.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
